### PR TITLE
Fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Protocol descriptions:
 
 ## SNORKs
 
-> SNORK = **S**uccinct **O**ecumenical (Universal) **AR**guments of **K**nowledge
+> SNORK = **S**uccinct **N**on-interactive **O**ecumenical (Universal) a**R**guments of **K**nowledge
 
 SNORKs are SNARKs with universal and updateable trusted setup.
 


### PR DESCRIPTION
The letters "SNORK" stand for "Succinct Non-interactive Oecumenical aRguments of Knowledge."