### PR TITLE
Add the MoonMath Manual to "Learn" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Get started:
 - [Introduction to zk-SNARKs with examples](https://media.consensys.net/introduction-to-zksnarks-with-examples-3283b554fc3b)
 - [What are zk-SNARKs (Zcash blog)](https://z.cash/technology/zksnarks)
 - [BabySNARK- The simplest possible SNARK for NP. You know, for kids!](https://github.com/initc3/babySNARK)
+- [The MoonMath Manual to zk-SNARKs (A free learning resource for beginners to experts)](https://leastauthority.com/community-matters/moonmath-manual/)
 
 Why and How zk-SNARK Works:
 


### PR DESCRIPTION
I propose adding the MoonMath Manual to zk-SNARKs for inclusion in the "Learn" section of "SNARKS" in your document. It is designed for an audience with only minimal experience in cryptography and programming. It is a free download.