### PR TITLE
Add a C implementation of Bulletproofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ More complete curated list of implementations and scientific resources:
 ### Try
 - [Implementation in Haskell](https://github.com/adjoint-io/bulletproofs)
 - [Implementation in Rust](https://github.com/dalek-cryptography/bulletproofs)
+- [Implementation in C](https://github.com/Tongsuo-Project/Tongsuo)
 
 ### Proof system implementations:
 - [Programmable Constraint Systems for Bulletproofs](https://medium.com/interstellar/programmable-constraint-systems-for-bulletproofs-365b9feb92f7)


### PR DESCRIPTION
Tongsuo is a generic cryptography library with many algorithms and protocols supported. Recently Tongsuo added the support of Bulletproofs, both range and r1cs. Check the following pull requests:

https://github.com/Tongsuo-Project/Tongsuo/pull/342
https://github.com/Tongsuo-Project/Tongsuo/pull/407

So we think it's good to have a C language implementation in the doc.