### PR TITLE
Updated discord link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ More complete curated list of implementations and scientific resources:
 ### Other blockchains
 
 - [Zcash: Privacy-Protecting Digital Currency](https://z.cash) (SNARKs)
-  - [Community Chat](https://discordapp.com/invite/PhJY6Pm)
+  - [Community Chat](https://discord.com/invite/zcash)
   - [Forums](https://forum.zcashcommunity.com)
 - [Monero: Private Digital Currency](https://www.getmonero.org) (Bulletproofs)
 - [Mina Protocol: A Constant-Size Blockchain](https://minaprotocol.com/) (recursive SNARKs)


### PR DESCRIPTION
Came across a deadlink while reading the README file. Since discord links can be hijacked for malicious purposes (happened on AleoHQ recently), I fixed it to a working one

Current link : https://discordapp.com/invite/PhJY6Pm
New link : https://discord.com/invite/zcash

Found that link on their official twitter : https://twitter.com/zcash/status/1748043470923547052