### PR TITLE
Fix: zk hack module 2 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 [ZK whiteboard sessions by ZK Hack](https://zkhack.dev/whiteboard/):
 
 - [Part 1: What is a SNARK?](https://zkhack.dev/whiteboard/module-one/)
-- [Part 2: Building a SNARK (Part I):](https://zkhack.dev/whiteboard/module-one/)
+- [Part 2: Building a SNARK (Part I):](https://zkhack.dev/whiteboard/module-two/)
 - [Part 3: Building a SNARK (Part 2)](https://zkhack.dev/whiteboard/module-three/)
 - [Part 4: SNARKS vs. STARKS](https://zkhack.dev/whiteboard/module-four/)
 - [Part 5: PLONK and Custom Gates with Adrian Hamelink](https://zkhack.dev/whiteboard/module-five/)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 [ZK whiteboard sessions by ZK Hack](https://zkhack.dev/whiteboard/):
 
 - [Part 1: What is a SNARK?](https://zkhack.dev/whiteboard/module-one/)
-- [Part 2: Building a SNARK (Part I):](https://zkhack.dev/whiteboard/module-two/)
+- [Part 2: Building a SNARK (Part 1):](https://zkhack.dev/whiteboard/module-two/)
 - [Part 3: Building a SNARK (Part 2)](https://zkhack.dev/whiteboard/module-three/)
 - [Part 4: SNARKS vs. STARKS](https://zkhack.dev/whiteboard/module-four/)
 - [Part 5: PLONK and Custom Gates with Adrian Hamelink](https://zkhack.dev/whiteboard/module-five/)


### PR DESCRIPTION
Part 2 of ZK hack Whiteboarding sessions points to the same one as part 1.

Update the part 2 module with the proper link